### PR TITLE
protect line endings for executable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Always preserve LF line endings in executables
+bin/splashicon-generator text eol=lf


### PR DESCRIPTION
Fixes #32

AFAICT the line endings for the executable are checked into the repo as LF, so all is good there. My best guess is that the NPM module was deployed from a Windows machine, and the executable was automatically converted to CRLF on Git checkout.

This .gitattributes file *should* instruct git to always preserve LF endings for the executable and prevent this from happening in the future, but I don't have a Windows machine to test it.