### PR TITLE
Remove Windows Phone 8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # splashicon-generator
 
-Automatic icon and splash screen resizing for any **Cordova** based applications including **PhoneGap**. It uses an ```icon.png``` and a ```splash.png``` to automatically resize and copy it for all the platforms your project supports (currently works with **iOS**, **Android** and **Windows Phone 8**).
+Automatic icon and splash screen resizing for any **Cordova** based applications including **PhoneGap**. It uses an ```icon.png``` and a ```splash.png``` to automatically resize and copy it for all the platforms your project supports (currently works with **iOS**, **Android** and **Windows 8.x**).
 
 Consider using the base icon and splash images in the `model` folder, so that images are not cropped and resized incorrectly.
 
@@ -111,10 +111,6 @@ Include in your ```config.xml``` file:
     <icon height="150" src="res/icons/windows/Wide310x150Logo.scale-100.png" width="310" />
     <icon height="360" src="res/icons/windows/Wide310x150Logo.scale-240.png" width="744" />
 </platform>
-<platform name="wp8">
-    <icon height="99" src="res/icons/wp8/ApplicationIcon.png" width="99" />
-    <icon height="159" src="res/icons/wp8/Background.png" width="159" />
-</platform>
 ```
 
 ---
@@ -157,12 +153,6 @@ Include in your ```config.xml``` file:
     <splash width="620" height="300" src="res/screens/windows/SplashScreen.scale-100.png" />
     <splash width="1152" height="1920" src="res/screens/windows/SplashScreen.scale-240.png" />
     <splash width="1152" height="1920" src="res/screens/windows/SplashScreenPhone.scale-240.png" />
-</platform>
-<platform name="wp8">
-    <splash width="768" height="1280" src="res/screens/wp8/SplashScreenImage.jpg" />
-    <splash width="720" height="1280" src="res/screens/wp8/SplashScreenImage.screen-720p.jpg" />
-    <splash width="480" height="800" src="res/screens/wp8/SplashScreenImage.screen-WVGA.jpg" />
-    <splash width="768" height="1280" src="res/screens/wp8/SplashScreenImage.screen-WXGA.jpg" />
 </platform>
 ```
 

--- a/index.js
+++ b/index.js
@@ -87,17 +87,6 @@ var getPlatformIcons = function () {
 
     //ok
     platforms.push({
-        name: 'wp8',
-        iconsPath: 'res/icons/wp8/',
-        isAdded: true,
-        icons: [
-            { name: 'ApplicationIcon.png', size: 99 },
-            { name: 'Background.png', size: 159 },
-        ]
-    });
-
-    //ok
-    platforms.push({
         name: 'windows',
         iconsPath: 'res/icons/windows/',
         isAdded: true,
@@ -123,7 +112,6 @@ var getPlatformIcons = function () {
         isAdded: true,
         icons: [
             { path: './android/', name: "icon-512.png", size: 512 },
-            { path: './wp8/', name: "icon-300.png", size: 300 },
             { path: './ios/', name: "icon-1024.jpg", size: 1024 } // App Store
         ]
     });
@@ -183,20 +171,6 @@ var getPlatformSplashs = function () {
             { name: "screen-xxhdpi-landscape.png", width: 1600, height: 960, density: "land-xxhdpi" }, // 1600x960
             { name: "screen-xxxhdpi-portrait.png", width: 1280, height: 1920, density: "port-xxhdpi" }, // 1280x1920
             { name: "screen-xxxhdpi-landscape.png", width: 1920, height: 1280, density: "land-xxhdpi" } // 1920x1280
-        ]
-    });
-
-    //ok
-    // https://msdn.microsoft.com/en-us/library/windows/apps/ff769511(v=vs.105).aspx
-    platforms.push({
-        name: 'wp8',
-        isAdded: true,
-        splashPath: 'res/screens/wp8/',
-        splash: [
-            { width: 768, height: 1280, name: "SplashScreenImage.jpg" },
-            { width: 480, height: 800, name: "SplashScreenImage.screen-WVGA.jpg" },
-            { width: 768, height: 1280, name: "SplashScreenImage.screen-WXGA.jpg" },
-            { width: 720, height: 1280, name: "SplashScreenImage.screen-720p.jpg" }
         ]
     });
 


### PR DESCRIPTION
The platform is no longer supported by MS and Apps.
The generator produces assets for Windows 8.x that can be used on Windows Phone 8.1 as well as Windows 10 (Mobile).
